### PR TITLE
Add data flush in uart put function

### DIFF
--- a/risc_v/ch6/src/uart.rs
+++ b/risc_v/ch6/src/uart.rs
@@ -101,7 +101,14 @@ impl Uart {
 
 	pub fn put(&mut self, c: u8) {
 		let ptr = self.base_address as *mut u8;
+		loop {
+			// Wait until previous data is flushed
+			if unsafe { ptr.add(5).read_volatile() } & (1 << 5) != 0 {
+				break;
+			}
+		}
 		unsafe {
+			// Write data
 			ptr.add(0).write_volatile(c);
 		}
 	}


### PR DESCRIPTION
I found that when I print a lot of characters, QEMU will ignore some of them. After reading documentation about QEMU UART driver, I made some changes to `Uart::put`. The program now waits until `unsafe { ptr.add(5).read_volatile() } & (1 << 5)` becomes zero, which means previous data is flushed, before sending next character.